### PR TITLE
Dict instead of list in return of step()

### DIFF
--- a/gym_navigation/envs/navigation.py
+++ b/gym_navigation/envs/navigation.py
@@ -29,7 +29,7 @@ class Navigation(Env):
         # so that we have access to previous observation.
         self._do_update_observation()
 
-        return self._observation.copy(), reward, done, []
+        return self._observation.copy(), reward, done, {}
 
     @abstractmethod
     def _do_perform_action(self, action: int) -> None:


### PR DESCRIPTION
Returning a list as infos in the step() function gives an error for algorithms like PPO2 from stable_baselines as they try to call .get() on its elements. A dict, simply {} instead of [] fixes that issue and is the way official environments of gym do it too.